### PR TITLE
Liveness tests, worker point to node's IP and fix haproxy cfg build bug

### DIFF
--- a/templates/common/baremetal/files/baremetal-coredns.yaml
+++ b/templates/common/baremetal/files/baremetal-coredns.yaml
@@ -82,6 +82,25 @@ contents:
         volumeMounts:
         - name: conf-dir
           mountPath: "/etc/coredns"
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          failureThreshold: 3
+          timeoutSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 5
         terminationMessagePolicy: FallbackToLogsOnError
         imagePullPolicy: IfNotPresent
       hostNetwork: true

--- a/templates/master/00-master/baremetal/files/baremetal-haproxy-utils.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-haproxy-utils.yaml
@@ -19,9 +19,11 @@ contents:
         declare -r domain="$1"
         declare -r api_port="$2"
         local ip
-    
+        local members_ips=()
+
         for item in $(etcd_members "$domain"); do
-            if ip="$(first_a_addr "$item")" && [[ -n "$ip" ]]; then
+            if ip="$(first_a_addr "$item")" && [[ -n "$ip" ]] && [[ ! " ${members_ips[@]} " =~ " ${ip} " ]]; then
+                members_ips+=("$ip")
                 echo "   server $item ${ip}:$api_port weight 1 verify none check check-ssl inter 3s fall 3 rise 3"
             fi
         done

--- a/templates/master/00-master/baremetal/files/baremetal-haproxy.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-haproxy.yaml
@@ -112,6 +112,16 @@ contents:
           mountPath: "/etc/haproxy"
         - name: run-dir
           mountPath: "/var/run/haproxy"
+        livenessProbe:
+          initialDelaySeconds: 10
+          httpGet:
+            path: /healthz
+            port: 1936
+        readinessProbe:
+          initialDelaySeconds: 10
+          httpGet:
+            path: /healthz
+            port: 1936
         terminationMessagePolicy: FallbackToLogsOnError
         imagePullPolicy: IfNotPresent
       - name: haproxy-monitor

--- a/templates/master/00-master/baremetal/files/baremetal-keepalived.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-keepalived.yaml
@@ -115,6 +115,12 @@ contents:
         volumeMounts:
         - name: conf-dir
           mountPath: "/etc/keepalived"
+        livenessProbe:
+          exec:
+            command:
+            - pgrep
+            - keepalived
+          initialDelaySeconds: 10
         terminationMessagePolicy: FallbackToLogsOnError
         imagePullPolicy: IfNotPresent
       hostNetwork: true

--- a/templates/master/00-master/baremetal/files/baremetal-mdns-publisher.yaml
+++ b/templates/master/00-master/baremetal/files/baremetal-mdns-publisher.yaml
@@ -96,6 +96,12 @@ contents:
         volumeMounts:
         - name: conf-dir
           mountPath: "/etc/mdns"
+        livenessProbe:
+          exec:
+            command:
+            - pgrep
+            - mdns-publisher
+          initialDelaySeconds: 10
         terminationMessagePolicy: FallbackToLogsOnError
         imagePullPolicy: IfNotPresent
       hostNetwork: true

--- a/templates/worker/00-worker/baremetal/files/NetworkManager-dns-vip-prepender-worker.yaml
+++ b/templates/worker/00-worker/baremetal/files/NetworkManager-dns-vip-prepender-worker.yaml
@@ -12,21 +12,28 @@ contents:
         pre-up)
         logger -s "NM dns-vip-prepender-worker triggered by pre-upping ${1}."
         CLUSTER_DOMAIN="$(/usr/local/bin/clusterinfo DOMAIN)"
-        API_VIP="127.0.0.1"
+        if ! HOST_QUERY="$(host ns1.${CLUSTER_DOMAIN})" ; then
+            logger -s "NM dns-vip-prepender: nameserver could not be resolved, exiting"
+            exit 0
+        fi
+        DNS_VIP=$(echo "${HOST_QUERY}" | awk '{print $NF}')
+        IFACE_CIDRS="$(ip addr show | grep -v "scope host" | grep -Po 'inet \K[\d.]+/[\d.]+' | xargs)"
+        SUBNET_CIDR="$(/usr/local/bin/get_vip_subnet_cidr "$DNS_VIP" "$IFACE_CIDRS")"
+        WORKER_BM_IP="$(ip -o addr show to "$SUBNET_CIDR" | awk '{print $4}' | awk -F/ '{print $1}')"
         set +e
-        if [[ -n $API_VIP ]]; then
-            logger -s "NM dns-vip-prepender-worker: Checking if API VIP is the first entry in resolv.conf"
-            if grep nameserver /etc/resolv.conf | head -n 1 | grep -q "$API_VIP" ; then
-                logger -s "NM dns-vip-prepender-worker: API VIP already the first entry in resolv.conf"
+        if [[ -n $WORKER_BM_IP ]]; then
+            logger -s "NM dns-vip-prepender-worker: Checking if worker node IP is the first entry in resolv.conf"
+            if grep nameserver /etc/resolv.conf | head -n 1 | grep -q "$WORKER_BM_IP" ; then
+                logger -s "NM dns-vip-prepender-worker: worker node IP already the first entry in resolv.conf"
                 exit 0
             else
-                export API_VIP
-    
-                logger -s "NM dns-vip-prepender-worker: Setting dhclient to prepend API VIP in resolv.conf"
+                export WORKER_BM_IP
+
+                logger -s "NM dns-vip-prepender-worker: Setting dhclient to prepend DNS VIP in resolv.conf"
                 envsubst < /etc/dhcp/dhclient.conf.template | tee /etc/dhcp/dhclient.conf
-    
-                logger -s "NM dns-vip-prepender-worker: Looking for 'search $CLUSTER_DOMAIN' in /etc/resolv.conf to place 'nameserver $API_VIP'"
-                sed -i "/^search .*$/a nameserver $API_VIP" /etc/resolv.conf
+
+                logger -s "NM dns-vip-prepender-worker: Looking for 'search $CLUSTER_DOMAIN' in /etc/resolv.conf to place 'nameserver $WORKER_BM_IP'"
+                sed -i "/^search .*$/a nameserver $WORKER_BM_IP" /etc/resolv.conf
             fi
         fi
         ;;

--- a/templates/worker/00-worker/baremetal/files/baremetal-mdns-publisher.yaml
+++ b/templates/worker/00-worker/baremetal/files/baremetal-mdns-publisher.yaml
@@ -93,6 +93,12 @@ contents:
         volumeMounts:
         - name: conf-dir
           mountPath: "/etc/mdns"
+        livenessProbe:
+          exec:
+            command:
+            - pgrep
+            - mdns-publisher
+          initialDelaySeconds: 10
         terminationMessagePolicy: FallbackToLogsOnError
         imagePullPolicy: IfNotPresent
       hostNetwork: true


### PR DESCRIPTION
This commit adds liveness tests for the coredns,mdns-publisher,
haproxy and keepalived static pods, changes worker node
/etc/resolv.conf to point to node's IP instead of 127.0.0.1 and
fix the bug generating haproxy cfg file

<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
